### PR TITLE
Add T-006 Munger Snap heuristics tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/t006_munger_snap/__init__.py
+++ b/t006_munger_snap/__init__.py
@@ -1,0 +1,12 @@
+"""Munger Snap utilities."""
+
+from .logic import FilterResult, Snapshot, four_filters
+
+__all__ = ["FilterResult", "Snapshot", "four_filters", "create_app"]
+
+
+def create_app():
+    """Factory wrapper that defers the Flask import."""
+    from .app import create_app as _create_app
+
+    return _create_app()

--- a/t006_munger_snap/app.py
+++ b/t006_munger_snap/app.py
@@ -1,0 +1,57 @@
+"""Flask entry point for Munger Snap."""
+from __future__ import annotations
+
+from flask import Flask, render_template, request
+
+from .logic import four_filters
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route("/", methods=["GET"])
+    def index() -> str:
+        return render_template(
+            "index.html",
+            result=None,
+            thesis="",
+            pe_input="",
+            fcf_input="",
+            error=None,
+            char_count=0,
+        )
+
+    @app.route("/snap", methods=["POST"])
+    def snap() -> str:
+        thesis = request.form.get("thesis", "").strip()
+        pe_input = request.form.get("pe", "").strip()
+        fcf_input = request.form.get("fcf_yield", "").strip()
+
+        error = None
+        if not thesis:
+            error = "Add a brief 6–10 line thesis to score."
+        elif len(thesis) > 1200:
+            error = "Trim input to 1,200 characters."
+
+        result = None
+        if error is None:
+            result = four_filters(thesis, pe_input or None, fcf_input or None)
+
+        return render_template(
+            "index.html",
+            result=result,
+            thesis=thesis,
+            pe_input=pe_input,
+            fcf_input=fcf_input,
+            error=error,
+            char_count=len(thesis),
+        )
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/t006_munger_snap/logic.py
+++ b/t006_munger_snap/logic.py
@@ -1,0 +1,347 @@
+"""Logic for Munger Snap heuristics."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+
+MOAT_KEYWORDS: Dict[str, str] = {
+    "network effect": "Network effects",
+    "network effects": "Network effects",
+    "switching cost": "Switching costs",
+    "switching costs": "Switching costs",
+    "brand": "Brand strength",
+    "flywheel": "Flywheel",
+    "scale": "Scale advantage",
+    "cost advantage": "Cost advantage",
+    "distribution": "Distribution reach",
+    "regulation": "Regulatory license",
+}
+
+MANAGEMENT_POSITIVE: Dict[str, str] = {
+    "founder-led": "Founder-led",
+    "founder led": "Founder-led",
+    "owner-operator": "Owner-operator",
+    "owner operator": "Owner-operator",
+    "insider ownership": "Insider ownership",
+    "insider-owned": "Insider ownership",
+    "buyback": "Buybacks",
+    "buybacks": "Buybacks",
+    "roic": "High ROIC",
+    "return on capital": "Returns on capital",
+    "capital allocator": "Capital allocation",
+    "capital allocation": "Capital allocation",
+    "skin in the game": "Skin in the game",
+}
+
+MANAGEMENT_RED_FLAGS: Dict[str, str] = {
+    "restatement": "Accounting restatement",
+    "probe": "Regulatory probe",
+    "investigation": "Investigation",
+    "fraud": "Fraud mention",
+    "lawsuit": "Shareholder lawsuit",
+    "sec": "SEC scrutiny",
+    "resignation": "Leadership turnover",
+}
+
+BIAS_KEYWORDS: Dict[str, Tuple[str, List[str]]] = {
+    "Incentives": (
+        "Incentives",
+        [
+            "bonus",
+            "commission",
+            "fees",
+            "subsidy",
+            "rebate",
+            "kickback",
+            "option",
+            "equity comp",
+            "stock grant",
+            "performance pay",
+            "founder-led",
+            "founder led",
+            "founder",
+            "buyback",
+            "buybacks",
+            "yield",
+            "fcf",
+            "owner-operator",
+            "owner operator",
+            "insider ownership",
+        ],
+    ),
+    "Social-Proof": (
+        "Social-Proof",
+        [
+            "customers",
+            "peers",
+            "trend",
+            "hype",
+            "viral",
+            "adoption",
+            "reference",
+            "case study",
+            "industry standard",
+            "partnership",
+            "network effect",
+            "network effects",
+            "switching cost",
+            "switching costs",
+            "integrations",
+            "integration",
+            "community",
+        ],
+    ),
+    "Commitment/Consistency": (
+        "Commitment/Consistency",
+        [
+            "long-term contract",
+            "multi-year",
+            "switching cost",
+            "switching costs",
+            "integrations",
+            "installed base",
+            "locked in",
+            "legacy system",
+            "prior investment",
+        ],
+    ),
+    "Authority": (
+        "Authority",
+        [
+            "regulator",
+            "regulators",
+            "regulation",
+            "mandate",
+            "government",
+            "board approval",
+            "expert",
+            "advisor",
+            "consultant",
+        ],
+    ),
+}
+
+INVERSION_RULES: List[Tuple[List[str], str]] = [
+    (
+        ["network effect", "network effects"],
+        "What breaks network effects? (regulatory fee caps, platform API changes, competitor subsidies).",
+    ),
+    (
+        ["switching cost", "switching costs"],
+        "What erodes switching costs? (migration tooling, interoperability mandates, bundled pricing).",
+    ),
+    (
+        ["brand"],
+        "Where does the brand lose trust? (quality lapses, pricing power pushback, reputational hits).",
+    ),
+    (
+        ["cost advantage", "scale"],
+        "Who undercuts the cost advantage? (input inflation, vertical integration, price wars).",
+    ),
+    (
+        ["regulation", "license"],
+        "How could regulation flip? (license removal, new entrants approved, compliance burdens).",
+    ),
+]
+
+
+@dataclass
+class FilterResult:
+    status: str
+    details: str = ""
+    hits: List[str] | None = None
+
+
+@dataclass
+class Snapshot:
+    filters: Dict[str, FilterResult]
+    invert: str
+    biases: List[str]
+    posture: str
+    copy_text: str
+
+
+def _tokenize_words(text: str) -> List[str]:
+    return re.findall(r"[a-zA-Z0-9']+", text.lower())
+
+
+def _count_sentences(text: str) -> List[str]:
+    parts = re.split(r"[.!?]+", text)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _count_paragraphs(text: str) -> int:
+    paragraphs = [p for p in re.split(r"\n\s*\n", text) if p.strip()]
+    return len(paragraphs) if paragraphs else (1 if text.strip() else 0)
+
+
+def _parse_number(raw: str | None) -> float | None:
+    if raw is None:
+        return None
+    text = raw.strip().lower()
+    if not text:
+        return None
+    text = text.replace("%", "")
+    text = text.replace("~", "")
+    match = re.search(r"-?\d+(?:\.\d+)?", text)
+    if not match:
+        return None
+    try:
+        return float(match.group(0))
+    except ValueError:
+        return None
+
+
+def _score_understandable(thesis: str) -> FilterResult:
+    cleaned = thesis.strip()
+    if not cleaned:
+        return FilterResult("Fail", "Add a concise thesis summary.")
+
+    sentences = _count_sentences(cleaned)
+    words = _tokenize_words(cleaned)
+    first_sentence_words = _tokenize_words(sentences[0]) if sentences else []
+    long_words = [w for w in words if len(w) > 12]
+    long_word_ratio = len(long_words) / max(len(words), 1)
+    paragraphs = _count_paragraphs(cleaned)
+
+    conditions = {
+        "summary": len(first_sentence_words) <= 30,
+        "jargon": long_word_ratio <= 0.2,
+        "segments": paragraphs <= 2,
+    }
+
+    if all(conditions.values()):
+        return FilterResult("Pass", "Clear one-sentence hook; jargon in check.")
+
+    misses: List[str] = []
+    if not conditions["summary"]:
+        misses.append("Add a <=30 word summary line up top.")
+    if not conditions["jargon"]:
+        misses.append("High jargon density—clarify plain language.")
+    if not conditions["segments"]:
+        misses.append("Too many disjoint segments—tighten focus.")
+    return FilterResult("Fail", " ".join(misses))
+
+
+def _score_moat(thesis: str) -> FilterResult:
+    text = thesis.lower()
+    hits: List[str] = []
+    for keyword, label in MOAT_KEYWORDS.items():
+        if keyword in text and label not in hits:
+            hits.append(label)
+    if hits:
+        return FilterResult("Pass", ", ".join(hits), hits=hits)
+    return FilterResult("Fail", "Spell out the moat (network effects, switching costs, brand, cost advantage).")
+
+
+def _score_management(thesis: str) -> FilterResult:
+    text = thesis.lower()
+    positives: List[str] = []
+    for keyword, label in MANAGEMENT_POSITIVE.items():
+        if keyword in text and label not in positives:
+            positives.append(label)
+    negatives: List[str] = []
+    for keyword, label in MANAGEMENT_RED_FLAGS.items():
+        if keyword in text and label not in negatives:
+            negatives.append(label)
+
+    if negatives:
+        return FilterResult("Fail", f"Red flags: {', '.join(negatives)}")
+    if positives:
+        return FilterResult("Pass", ", ".join(positives))
+    return FilterResult("Fail", "Note owner-operator traits, insider ownership, or capital allocation history.")
+
+
+def _score_margin_of_safety(pe_text: str | None, fcf_yield_text: str | None) -> FilterResult:
+    pe = _parse_number(pe_text)
+    fcf_yield = _parse_number(fcf_yield_text)
+
+    if pe is not None and pe <= 15:
+        return FilterResult("Pass", f"P/E {pe:.1f} within <=15 guardrail.")
+    if fcf_yield is not None and fcf_yield >= 6:
+        return FilterResult("Pass", f"FCF yield {fcf_yield:.1f}% clears >=6% bar.")
+
+    if pe is not None or fcf_yield is not None:
+        details: List[str] = []
+        if pe is not None:
+            details.append(f"P/E {pe:.1f} > 15")
+        if fcf_yield is not None:
+            details.append(f"FCF yield {fcf_yield:.1f}% < 6%")
+        return FilterResult("Fail", "; ".join(details))
+
+    return FilterResult("Needs Data", "— add P/E or FCF-yield to judge MOS.")
+
+
+def _rank_biases(thesis: str) -> List[str]:
+    text = thesis.lower()
+    ordered_biases: List[str] = []
+    triggered: List[str] = []
+    for _, (display, keywords) in BIAS_KEYWORDS.items():
+        ordered_biases.append(display)
+        if any(keyword in text for keyword in keywords):
+            triggered.append(display)
+
+    final: List[str] = []
+    for bias in ordered_biases:
+        if bias in triggered and bias not in final:
+            final.append(bias)
+    for bias in ordered_biases:
+        if bias not in final:
+            final.append(bias)
+    return final[:3]
+
+
+def _invert_question(thesis: str, moat_result: FilterResult) -> str:
+    text = thesis.lower()
+    if moat_result.hits:
+        moat_hits = [hit.lower() for hit in moat_result.hits]
+    else:
+        moat_hits = []
+    for keywords, prompt in INVERSION_RULES:
+        if any(k in text for k in keywords):
+            return prompt
+        if moat_hits and any(any(k in hit for k in keywords) for hit in moat_hits):
+            return prompt
+    return "What would have to be true for this to fail? Pressure-test customer churn, pricing power, and management behavior."
+
+
+def _posture(filters: Dict[str, FilterResult]) -> str:
+    passes = sum(1 for f in filters.values() if f.status == "Pass")
+    fails = sum(1 for f in filters.values() if f.status == "Fail")
+    needs = sum(1 for f in filters.values() if f.status == "Needs Data")
+
+    if fails >= 2:
+        return "No"
+    if fails == 0 and needs == 0 and passes >= 3:
+        return "Go"
+    return "Wait"
+
+
+def _build_copy(filters: Dict[str, FilterResult], invert: str, biases: List[str], posture: str) -> str:
+    lines = ["Four-Filters Snapshot"]
+    for name, result in filters.items():
+        detail = f" — {result.details}" if result.details else ""
+        lines.append(f"{name}: {result.status}{detail}")
+    lines.append(f"Invert: {invert}")
+    lines.append("Bias Risks: " + ", ".join(biases))
+    lines.append(f"Posture: {posture}")
+    return "\n".join(lines)
+
+
+def four_filters(thesis: str, pe_text: str | None = None, fcf_yield_text: str | None = None) -> Snapshot:
+    filters = {
+        "Understandable": _score_understandable(thesis),
+        "Moat": _score_moat(thesis),
+        "Management": _score_management(thesis),
+        "Margin of Safety": _score_margin_of_safety(pe_text, fcf_yield_text),
+    }
+    invert = _invert_question(thesis, filters["Moat"])
+    biases = _rank_biases(thesis)
+    posture = _posture(filters)
+    copy_text = _build_copy(filters, invert, biases, posture)
+    return Snapshot(filters=filters, invert=invert, biases=biases, posture=posture, copy_text=copy_text)
+
+
+__all__ = ["four_filters", "Snapshot", "FilterResult"]

--- a/t006_munger_snap/templates/index.html
+++ b/t006_munger_snap/templates/index.html
@@ -1,0 +1,282 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Munger Snap — Four Filters</title>
+    <style>
+      :root {
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        color: #222;
+        background: #f7f7f7;
+      }
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      .container {
+        max-width: 760px;
+        margin: 0 auto;
+        padding: 32px 20px 60px;
+      }
+      header {
+        margin-bottom: 24px;
+      }
+      h1 {
+        font-size: 1.8rem;
+        margin-bottom: 0.5rem;
+      }
+      p.lead {
+        margin: 0;
+        color: #555;
+      }
+      form {
+        background: #fff;
+        border-radius: 12px;
+        padding: 24px;
+        box-shadow: 0 6px 16px rgba(0,0,0,0.07);
+        display: grid;
+        gap: 16px;
+      }
+      label {
+        font-weight: 600;
+        display: block;
+        margin-bottom: 6px;
+      }
+      textarea, input[type="text"] {
+        width: 100%;
+        padding: 12px;
+        border-radius: 8px;
+        border: 1px solid #d0d6dd;
+        font-size: 1rem;
+        box-sizing: border-box;
+      }
+      textarea {
+        resize: vertical;
+        min-height: 160px;
+      }
+      .metrics {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 12px;
+      }
+      .actions {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      button[type="submit"], button.copy-btn {
+        background: #111827;
+        color: #fff;
+        border: none;
+        padding: 12px 18px;
+        border-radius: 8px;
+        font-size: 1rem;
+        cursor: pointer;
+      }
+      button.copy-btn {
+        background: #1f2937;
+      }
+      .char-count {
+        font-size: 0.9rem;
+        color: #6b7280;
+        text-align: right;
+      }
+      .error {
+        margin-top: 12px;
+        color: #b91c1c;
+        font-weight: 600;
+      }
+      section.snapshot {
+        margin-top: 32px;
+        background: #fff;
+        border-radius: 12px;
+        padding: 24px;
+        box-shadow: 0 6px 16px rgba(0,0,0,0.07);
+      }
+      section.snapshot h2 {
+        margin-top: 0;
+      }
+      ul.filters {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 12px;
+      }
+      ul.filters li {
+        padding: 12px 14px;
+        border-radius: 10px;
+        border: 1px solid #e5e7eb;
+        background: #f9fafb;
+      }
+      ul.filters li.pass {
+        border-color: #22c55e;
+        background: #ecfdf5;
+      }
+      ul.filters li.fail {
+        border-color: #ef4444;
+        background: #fef2f2;
+      }
+      ul.filters li[data-status="Needs Data"], ul.filters li.needs-data {
+        border-color: #fbbf24;
+        background: #fffbeb;
+      }
+      ul.filters li strong {
+        display: block;
+        font-size: 1.05rem;
+      }
+      ul.filters li span.status {
+        font-weight: 700;
+      }
+      .details {
+        margin-top: 4px;
+        color: #374151;
+        font-size: 0.95rem;
+      }
+      .section {
+        margin-top: 18px;
+      }
+      .section h3 {
+        margin: 0 0 6px;
+      }
+      .bias-tags {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .bias-tags span {
+        background: #e0e7ff;
+        color: #1e3a8a;
+        padding: 6px 10px;
+        border-radius: 999px;
+        font-size: 0.9rem;
+      }
+      .posture {
+        margin-top: 20px;
+        font-size: 1.2rem;
+        font-weight: 700;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .posture span.label {
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        font-size: 0.85rem;
+        color: #6b7280;
+      }
+      @media (max-width: 640px) {
+        form {
+          padding: 20px;
+        }
+        section.snapshot {
+          padding: 20px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>Munger Snap — Four-Filter Pass</h1>
+        <p class="lead">Paste a thesis to get Understandable, Moat, Management, and Margin-of-Safety calls plus one inversion prompt.</p>
+      </header>
+      <form method="post" action="{{ url_for('snap') }}">
+        <div>
+          <label for="thesis">6–10 line thesis</label>
+          <textarea id="thesis" name="thesis" maxlength="1200" required>{{ thesis }}</textarea>
+          <div class="char-count">
+            {{ (char_count or 0) }} / 1200
+          </div>
+        </div>
+        <div class="metrics">
+          <div>
+            <label for="pe">P/E (optional)</label>
+            <input id="pe" type="text" name="pe" placeholder="e.g. 14" value="{{ pe_input }}">
+          </div>
+          <div>
+            <label for="fcf_yield">FCF Yield % (optional)</label>
+            <input id="fcf_yield" type="text" name="fcf_yield" placeholder="e.g. 6.5" value="{{ fcf_input }}">
+          </div>
+        </div>
+        <div class="actions">
+          <button type="submit">Run Four-Filters Snap</button>
+        </div>
+        {% if error %}
+          <div class="error">{{ error }}</div>
+        {% endif %}
+      </form>
+
+      {% if result %}
+        <section class="snapshot" id="snapshot">
+          <h2>Four-Filters Snapshot</h2>
+          <ul class="filters">
+            {% for name, data in result.filters.items() %}
+              {% set status_class = data.status|lower().replace(' ', '-') %}
+              <li class="{{ status_class }}" data-status="{{ data.status }}">
+                <strong>{{ name }}</strong>
+                <span class="status">{{ data.status }}</span>
+                {% if data.details %}
+                  <div class="details">{{ data.details }}</div>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+          <div class="section">
+            <h3>Invert</h3>
+            <p>{{ result.invert }}</p>
+          </div>
+          <div class="section">
+            <h3>Top Bias Risks</h3>
+            <div class="bias-tags">
+              {% for bias in result.biases %}
+                <span>{{ bias }}</span>
+              {% endfor %}
+            </div>
+          </div>
+          <div class="posture">
+            <span class="label">Posture</span>
+            <span>{{ result.posture }}</span>
+          </div>
+          <div class="section">
+            <button type="button" class="copy-btn" id="copy-snapshot" data-copy="{{ result.copy_text | replace('\n', '&#10;') }}">Copy Snapshot</button>
+            <span id="copy-feedback" style="margin-left:12px;color:#16a34a;font-weight:600;display:none;">Copied</span>
+          </div>
+        </section>
+      {% endif %}
+    </div>
+    <script>
+      const textarea = document.getElementById('thesis');
+      const charCount = document.querySelector('.char-count');
+      const copyButton = document.getElementById('copy-snapshot');
+      const copyFeedback = document.getElementById('copy-feedback');
+
+      if (textarea && charCount) {
+        const updateCount = () => {
+          charCount.textContent = `${textarea.value.length} / 1200`;
+        };
+        textarea.addEventListener('input', updateCount);
+        updateCount();
+      }
+
+      if (copyButton) {
+        copyButton.addEventListener('click', async () => {
+          const text = copyButton.getAttribute('data-copy');
+          try {
+            await navigator.clipboard.writeText(text.replace(/&#10;/g, '\n'));
+            if (copyFeedback) {
+              copyFeedback.style.display = 'inline';
+              setTimeout(() => {
+                copyFeedback.style.display = 'none';
+              }, 1800);
+            }
+          } catch (err) {
+            console.error('Copy failed', err);
+          }
+        });
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement the four-filter scoring logic with transparent heuristics, inversion prompts, and bias matching
- expose a lightweight Flask app and template for collecting theses and showing the snapshot with copy support
- add package helper and ignore Python bytecode artifacts

## Testing
- python -m compileall t006_munger_snap

------
https://chatgpt.com/codex/tasks/task_e_68c95132359883268c775b14d78b7f2d